### PR TITLE
Feature: add ebi 1.x banner

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,42 @@
+import React from "react"
+import PropTypes from "prop-types"
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no"
+        />
+        {props.headComponents}
+        {/* For the legacy 1.x EBI Global head (black bar) */}
+        <script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js"></script>
+        <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
+      </head>
+      <body {...props.bodyAttributes}>
+        {props.preBodyComponents}
+        {/* For the legacy 1.x EBI Global head (black bar) */}
+        <header id="masthead-black-bar" className="clearfix masthead-black-bar | ebi-header-footer vf-content vf-u-fullbleed"></header>
+        <div
+          key={`body`}
+          id="___gatsby"
+          class="vf-body | vf-stack vf-stack--400"
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  )
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array,
+}

--- a/src/html.js
+++ b/src/html.js
@@ -7,14 +7,7 @@ export default function HTML(props) {
       <head>
         <meta charSet="utf-8" />
         <meta httpEquiv="x-ua-compatible" content="ie=edge" />
-        <meta
-          name="viewport"
-          content="width=device-width, initial-scale=1, shrink-to-fit=no"
-        />
         {props.headComponents}
-        {/* For the legacy 1.x EBI Global head (black bar) */}
-        <script src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js"></script>
-        <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
       </head>
       <body {...props.bodyAttributes}>
         {props.preBodyComponents}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,6 +16,9 @@ const IndexPage = () => {
           class: ''
         }}>
         <title>The European Bioinformatics Institute &lt; EMBL-EBI</title>
+        {/* For the legacy 1.x EBI Global head (black bar) */}
+        <script defer="defer" src="https://ebi.emblstatic.net/web_guidelines/EBI-Framework/v1.4/js/script.js"></script>
+        <link rel="stylesheet" href="https://ebi.emblstatic.net/web_guidelines/EBI-Icon-fonts/v1.3/fonts.css" type="text/css" media="all" />
       </Helmet>
 
       <EmblHeader />

--- a/src/pages/styles.scss
+++ b/src/pages/styles.scss
@@ -194,3 +194,6 @@ button {
 // If you have any local overrides, put them in:
 // @import '../vf-sample/vf-sample.scss';
 // @import "../vf-local-overrides/vf-local-overrides.scss";
+
+// ideally we don't need this, but there are some nested divs required for gatsby
+body { margin: 0; }

--- a/src/pages/styles.scss
+++ b/src/pages/styles.scss
@@ -166,7 +166,7 @@ button {
 /* EBI Specific components */
 // ebi-header-footer is not enabled by default
 // this may change as more EBI sites move to "pure" sVF 2.0
-// @import 'ebi-header-footer/ebi-header-footer.scss';
+@import "@visual-framework/ebi-header-footer/ebi-header-footer.scss";
 // @import 'node_modules/@visual-framework/ebi-vf1-integration/ebi-vf1-integration.scss';
 
 /* All Visual Framework Utility and high-specificity components */


### PR DESCRIPTION
The EBI 1.x banner doesn't play nicely (not a JS module) so works best when added at the as "raw" js.

![image](https://user-images.githubusercontent.com/928100/121718112-337a3a00-cae2-11eb-8ac7-dafa5f29f4b3.png)
